### PR TITLE
[Feat/31] GA 로그 심기

### DIFF
--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -91,9 +91,8 @@ fun HomeScreen(
                 val screenName = if (isHome) Screen.Home.name else Screen.BottomSheetCustom.name
 
                 // 앱 메인 페이지 진입 & 맞춤정보 바텀시트 노출
-                Firebase.analytics.logEvent("pageView") {
+                Firebase.analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
                     param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
-                    param("navigation", screenName)
                 }
             }
     }
@@ -138,9 +137,8 @@ private fun HomeScreen(
                 val screenName = if (isHome) Screen.Home.name else Screen.NewsLetterCarousel.name
 
                 // 앱 메인 페이지 진입 & 뉴스레터 캐러셀 진입
-                Firebase.analytics.logEvent("pageView") {
+                Firebase.analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
                     param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
-                    param("navigation", screenName)
                 }
             }
     }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -107,7 +107,7 @@ fun HomeScreen(
                     preferences = preferences,
                     workingExperience = workingExperience
                 )
-                buttonClickEvent(jobGroud = preferences, careerLevel = workingExperience)
+                buttonClickEvent(jobGroup = preferences, careerLevel = workingExperience)
             }
         )
     }
@@ -393,12 +393,12 @@ private fun Card(
     }
 }
 
-private fun buttonClickEvent(jobGroud: List<String>, careerLevel: String) {
+private fun buttonClickEvent(jobGroup: List<String>, careerLevel: String) {
     // 맞춤정보 바텀시트_맞춤정보 보기 버튼 클릭
     Firebase.analytics.logEvent("click") {
         param("navigation", Screen.BottomSheetCustom.name)
         param("object_type", "button")
-        param("job_group", jobGroud.joinToString(separator = ","))
+        param("job_group", jobGroup.joinToString(separator = ","))
         param("career_level", careerLevel)
     }
 }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -42,10 +42,6 @@ import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
-import com.google.firebase.Firebase
-import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.analytics
-import com.google.firebase.analytics.logEvent
 import com.fairyband.soak.core.extension.bounceClick
 import com.fairyband.soak.core.theme.SoakTheme
 import com.fairyband.soak.presentation.R
@@ -53,6 +49,10 @@ import com.fairyband.soak.presentation.feature.home.bottomsheet.HomeBottomSheet
 import com.fairyband.soak.presentation.feature.home.dialog.PopUpDialog
 import com.fairyband.soak.presentation.model.NewsFeed
 import com.fairyband.soak.presentation.navigation.Screen
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
@@ -89,9 +89,11 @@ fun HomeScreen(
         snapshotFlow { bottomSheetVisibility }
             .collect { isHome ->
                 val screenName = if (isHome) Screen.Home.name else Screen.BottomSheetCustom.name
-                Firebase.analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+
+                // 앱 메인 페이지 진입 & 맞춤정보 바텀시트 노출
+                Firebase.analytics.logEvent("pageView") {
                     param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
-                    param("platform", "Android")
+                    param("navigation", screenName)
                 }
             }
     }
@@ -106,6 +108,7 @@ fun HomeScreen(
                     preferences = preferences,
                     workingExperience = workingExperience
                 )
+                buttonClickEvent(jobGroud = preferences, careerLevel = workingExperience)
             }
         )
     }
@@ -133,11 +136,28 @@ private fun HomeScreen(
             .distinctUntilChanged()
             .collect { isHome ->
                 val screenName = if (isHome) Screen.Home.name else Screen.NewsLetterCarousel.name
-                Firebase.analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
+
+                // 앱 메인 페이지 진입 & 뉴스레터 캐러셀 진입
+                Firebase.analytics.logEvent("pageView") {
                     param(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
-                    param("platform", "Android")
+                    param("navigation", screenName)
                 }
             }
+    }
+
+    LaunchedEffect(cardIndex, news) {
+        cardIndex?.let {
+            // 뉴스레터 클릭
+            Firebase.analytics.logEvent("click") {
+                val objectId = news.getOrNull(it)?.id.orEmpty()
+
+                param("navigation", Screen.Home.name)
+                param("object_section", "newsletter_list")
+                param("object_type", "newsletter")
+                param("object_id", objectId)
+                param("list_index", it.toLong())
+            }
+        }
     }
 
     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
@@ -372,6 +392,16 @@ private fun Card(
                 }
             }
         }
+    }
+}
+
+private fun buttonClickEvent(jobGroud: List<String>, careerLevel: String) {
+    // 맞춤정보 바텀시트_맞춤정보 보기 버튼 클릭
+    Firebase.analytics.logEvent("click") {
+        param("navigation", Screen.BottomSheetCustom.name)
+        param("object_type", "button")
+        param("job_group", jobGroud.joinToString(separator = ","))
+        param("career_level", careerLevel)
     }
 }
 

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/dialog/PopUpDialog.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/dialog/PopUpDialog.kt
@@ -20,7 +20,9 @@ import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +39,11 @@ import com.fairyband.soak.presentation.feature.home.dialog.PopUpDialogDefaults.C
 import com.fairyband.soak.presentation.feature.home.getCardTitleColors
 import com.fairyband.soak.presentation.model.NewsFeed
 import com.fairyband.soak.presentation.navigation.Screen
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.analytics.logEvent
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 internal object PopUpDialogDefaults {
     const val SUMMARY_MAX_LINE = 8
@@ -88,6 +94,24 @@ internal fun PopUpDialog(
                 initialPage = cardIndex
             )
 
+            LaunchedEffect(Unit) {
+                snapshotFlow { pagerState.currentPage }
+                    .distinctUntilChanged()
+                    .collect { page ->
+                        val item = cardItems[page]
+
+                        // 뉴스레터 캐러셀 카드 노출
+                        Firebase.analytics.logEvent("impression") {
+                            param("navigation", Screen.NewsLetterCarousel.name)
+                            param("object_section", "newsletter_card")
+                            param("object_type", "newsletter")
+                            param("object_id", item.id)
+                            param("card_index", page.toLong())
+
+                        }
+                    }
+            }
+
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally
@@ -114,6 +138,7 @@ internal fun PopUpDialog(
                         titleColor = titleColors[pageIndex],
                         onClick = {
                             navController.navigate(Screen.WebView(url = item.url))
+                            webClickEvent(id = item.id, page = pageIndex.toLong())
                         },
                     )
                 }
@@ -132,7 +157,6 @@ internal fun PopUpDialog(
             }
         }
     }
-
 }
 
 @Composable
@@ -157,5 +181,16 @@ private fun Indicator(
                     )
             )
         }
+    }
+}
+
+private fun webClickEvent(id: String, page: Long) {
+    // 뉴스레터 캐러셀 카드 내 ‘이어서 보기’ 버튼 클릭
+    Firebase.analytics.logEvent("click") {
+        param("navigation", Screen.NewsLetterCarousel.name)
+        param("object_section", "newsletter_card")
+        param("object_type", "button")
+        param("object_id", id)
+        param("card_index", page)
     }
 }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/dialog/PopUpDialog.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/dialog/PopUpDialog.kt
@@ -107,7 +107,6 @@ internal fun PopUpDialog(
                             param("object_type", "newsletter")
                             param("object_id", item.id)
                             param("card_index", page.toLong())
-
                         }
                     }
             }


### PR DESCRIPTION
## Issue
- closed #31

## Work Description
- 현재 구현되어 있는 기능에 한해 GA 로그 심었습니다!

# Screenshot

| 모든 이벤트 명 | screen_view 이벤트의 파라미터 값 |
|-------------|---------|
| <img width="284" height="314" alt="image" src="https://github.com/user-attachments/assets/47c4d37f-e193-445d-a3bc-edcb811c039c" />| <img width="280" height="323" alt="image" src="https://github.com/user-attachments/assets/07cd0520-30c2-4de4-8749-8c9cfc386017" /> |



## To Reviewers
- 이벤트들이 헷갈리기 쉬울 것 같아서 주석으로 구분해 두었습니당
- 화면 체류시간을 측정하려면 이벤트명을 "`FirebaseAnalytics.Event.SCREEN_VIEW`"로 해주어야 하는 것 같아서 pageView 이벤트들은 그렇게 심어놓았어요..! (아요랑 상의를 해봐야 하나..)