### PR TITLE
Qa/76 4가지 QA 사항을 수정했어요.

### DIFF
--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -147,7 +148,7 @@ private fun HomeScreen(
     news: ImmutableList<NewsFeed>,
     colorType: String,
 ) {
-    var cardIndex: Int? by remember { mutableStateOf(null) }
+    var cardIndex: Int? by rememberSaveable { mutableStateOf(null) }
 
     LaunchedEffect(Unit) {
         snapshotFlow { cardIndex }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -181,7 +181,9 @@ private fun HomeScreen(
     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
         Box {
             Column(
-                modifier = Modifier.padding(innerPadding),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 val today = LocalDate.now()

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -337,6 +338,7 @@ private fun Cards(
                 bottomPadding = bottomPaddings[index],
                 textStyle = textStyles[index],
                 showKeyword = keywordVisibilities[index],
+                visibleHeight = if (index < 3) 106 else null,
                 onHeightInflated = { height -> cardHeights[index] = height },
                 onClick = { onClick(index) },
             )
@@ -356,6 +358,7 @@ private fun Card(
     cardColor: Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    visibleHeight: Int? = null,
     showKeyword: Boolean = false,
     onHeightInflated: (height: Int) -> Unit,
 ) {
@@ -369,8 +372,14 @@ private fun Card(
             .clip(shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
             .background(color = cardColor)
     ) {
+        val columnModifier = if (visibleHeight == null) {
+            Modifier
+        } else {
+            Modifier.heightIn(visibleHeight.dp)
+        }
+
         Column(
-            modifier = Modifier
+            modifier = columnModifier
                 .fillMaxWidth()
                 .onGloballyPositioned { layoutCoordinates ->
                     onHeightInflated((layoutCoordinates.size.height / density.density).toInt())
@@ -383,7 +392,7 @@ private fun Card(
                 style = textStyle,
                 onTextLayout = { textLayoutResult ->
                     lineCount = textLayoutResult.lineCount
-                }
+                },
             )
             if (showKeyword || lineCount == 1) {
                 Row(

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -199,7 +200,10 @@ private fun HomeScreen(
                         today.monthValue.toString().padStart(2, '0'),
                         today.dayOfMonth.toString().padStart(2, '0')
                     ),
-                    style = SoakTheme.typography.title.copy(textAlign = TextAlign.Center),
+                    style = SoakTheme.typography.title.copy(
+                        textAlign = TextAlign.Center,
+                        fontSize = 24.sp,
+                    ),
                     color = SoakTheme.colors.textStrong,
                 )
                 Timer()
@@ -248,6 +252,7 @@ private fun Timer() {
         horizontalArrangement = Arrangement.spacedBy(1.dp),
         verticalAlignment = Alignment.Top,
     ) {
+        val suffixString = stringResource(R.string.home_limited_time_notice)
         val numberStyle = SoakTheme.typography.body16.copy(
             fontWeight = FontWeight.SemiBold,
             color = SoakTheme.colors.stateNegativePrimary
@@ -266,6 +271,14 @@ private fun Timer() {
         Text(mm, style = numberStyle)
         Text(":", style = colonStyle)
         Text(ss, style = numberStyle)
+        Text(
+            modifier = Modifier.padding(start = 2.dp),
+            text = suffixString,
+            style = SoakTheme.typography.body15.copy(
+                fontWeight = FontWeight.Medium,
+                color = SoakTheme.colors.textSecondary,
+            )
+        )
     }
 }
 

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/dialog/PopUpDialog.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/dialog/PopUpDialog.kt
@@ -1,5 +1,6 @@
 package com.fairyband.soak.presentation.feature.home.dialog
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -59,6 +60,10 @@ internal fun PopUpDialog(
     cardIndex: Int,
     colorType: String,
 ) {
+    BackHandler(visibility) {
+        onDismissRequest()
+    }
+
     val keywords = cardItems.map { it.keyword }
     val titleColors = remember(cardItems, colorType) { getCardTitleColors(colorType, keywords) }
 

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/webview/WebViewScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/webview/WebViewScreen.kt
@@ -3,13 +3,19 @@ package com.fairyband.soak.presentation.feature.webview
 import android.annotation.SuppressLint
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun WebViewScreen(url: String) {
     AndroidView(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding(),
         factory = { context ->
             WebView(context).apply {
                 webViewClient = WebViewClient()

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="home_notification_setting_title">가장 먼저 새로운 소식을 받아보세요</string>
     <string name="home_notification_setting_description">매일 유용한 뉴스레터를 보내드려요.</string>
     <string name="home_notification_setting_button">알림 받기</string>
+    <string name="home_limited_time_notice">동안 볼 수 있어요</string>
 </resources>


### PR DESCRIPTION
## Issue
- closed #76 

## Work Description
- 웹뷰 화면에서 상태바까지 웹뷰가 노출되는 것을 막았어요.
- 원문 보기 후 되돌아왔을 때 캐로셀이 사라지는 현상을 수정했어요.
- 캐로셀이 떠 있을 때 뒤로가기를 누르면 앱이 종료되는 현상을 수정했어요.
- 앱을 켠 직후 제목이 왼쪽으로 붙는 현상을 수정했어요.
- 앞의 3개 카드의 높이를 고정했어요.
- 제목의 크기를 수정했어요.

## Screenshot


## To Reviewers
- 살려줘...
