### PR TITLE
[FIX] 백그라운드에서 되돌아왔을 때 뉴스를 리프레시 하도록 변경했어요. 추가로 flow도 개선했어요.

### DIFF
--- a/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
@@ -5,15 +5,17 @@ import com.fairyband.soak.data.datasource.AuthDataSource
 import com.fairyband.soak.data.datasource.NewsLetterDataSource
 import com.fairyband.soak.data.model.response.NewsResponse
 import com.fairyband.soak.data.repository.NewsRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.time.delay
 import org.koin.core.annotation.Single
+import timber.log.Timber
+import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Single
 class NewsRepositoryImpl(
@@ -25,14 +27,20 @@ class NewsRepositoryImpl(
     // 매일 자정에 뉴스를 새로고침해요.
     private val dayFlow = flow {
         while (true) {
-            delay(1_000)
-            emit(LocalDate.now().dayOfMonth)
+            emit(Unit)
+            val midnight: LocalDateTime = LocalDate.now().plusDays(1).atStartOfDay()
+            val duration = Duration.between(LocalDateTime.now(), midnight)
+            Timber.d("뉴스 새로고침까지 ${duration.seconds}초 남았어요.")
+
+            delay(duration)
         }
-    }.distinctUntilChanged()
+    }
 
     override val news: Flow<List<NewsResponse>> =
-        merge(refreshFlow, dayFlow.map { Unit })
+        merge(refreshFlow, dayFlow)
             .map {
+                Timber.d("뉴스를 새로 불러왔어요.")
+
                 val userId = authDataSource.getUserId()
                 val publishedDate = LocalDate.now().toPattern("yyyy-MM-dd")
 


### PR DESCRIPTION
## Issue
- closed #99 

## Work Description
- 제목이 곧 내용이에요.

## Screenshot
<!-- <img src="이미지 주소" width=270 /> -->

## To Reviewers
- 근데 원래 로직도 정상 동작하는데, 제가 테스트했던 버전이 과거 버전이라 동작하지 않았던 거였어요. 그런데 코드 개선의 여지가 보여서 변경하긴 했습니다!
- 기존에는 매초마다 값을 방출했으나, 자정에만 값을 방출하도록 로직을 개선했어요.

## 백그라운드에서 포그라운드로 돌아올 때의 흐름 해석
- 앱이 백그라운드로 넘어가고 5초가 지나면 `SharingStarted.WhileSubscribed(5_000)`에 의해서 코루틴이 취소돼요. 
- 앱이 포그라운드로 돌아오면 news를 다시 구독해요.
- news는 cold flow이기 때문에 emit(Unit)이 일단 실행돼요.
- 따라서 news를 다시 불러와요.