### PR TITLE
Feat/92 카드 스크롤 애니메이션 v1

### DIFF
--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -90,7 +90,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
-import timber.log.Timber
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -543,12 +542,11 @@ private fun Cards(
                 onClick = { onClick(index) },
             )
         }
-
-        val lastIndex = news.size - 1
         val density = LocalDensity.current.density
 
         // 아래로 스와이프할 때 가장 뒤쪽 카드가 서서히 올라와요.
         if (progress > 0) {
+            val lastIndex = news.size - 1
             Card(
                 modifier = Modifier
                     .graphicsLayer { translationY = -progress * cardHeights[lastIndex] * density }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
+import timber.log.Timber
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -468,17 +469,16 @@ private fun Cards(
         if (news.isEmpty()) return@LaunchedEffect
 
         if (scrollAccum > stepPx) {
-            start = (start - 1 + news.size) % news.size
+            start = (start + 1) % news.size
             scrollAccum -= stepPx
         }
 
         if (scrollAccum < -stepPx) {
-            start = (start + 1) % news.size
+            start = (start - 1 + news.size) % news.size
             scrollAccum += stepPx
         }
 
         progress = scrollAccum / stepPx
-        println("${progress}, $scrollAccum, $stepPx")
     }
 
     LaunchedEffect(cardOffsets) {
@@ -520,34 +520,34 @@ private fun Cards(
             Card(
                 modifier = Modifier
                     .graphicsLayer {
-                        if (progress < 0 && index == news.size - 1) {
-                            val dy = cardHeights[index].toFloat() * progress * density.density
+                        if (progress < 0 && feedIndex == news.size - 1) {
+                            val dy = cardHeights[feedIndex].toFloat() * progress * density.density
                             translationY = -dy
                         } else {
-                            val dy = cardHeights[(index + 1).coerceAtMost(news.size - 1)].toFloat() * progress * density.density
+                            val dy = cardHeights[(feedIndex + 1).coerceAtMost(news.size - 1)].toFloat() * progress * density.density
                             translationY = dy
                         }
                     }
-                    .zIndex(5f - index)
-                    .offset(y = (166 - cardOffsets[index]).dp)
-                    .offset(y = animationList[index].value.dp)
-                    .padding(horizontal = ((index - progress).coerceAtLeast(0f) * 16).dp),
-                feed = news[feedIndex],
-                cardColor = cardColors[feedIndex],
-                topPadding = topPaddings[index],
-                bottomPadding = bottomPaddings[index],
-                textStyle = textStyles[index],
-                showKeyword = keywordVisibilities[index],
-                visibleHeight = if (index < 3) 106 else null,
-                onHeightInflated = { height -> cardHeights[index] = height },
-                onClick = { onClick(index) },
+                    .zIndex(5f - feedIndex)
+                    .offset(y = (166 - cardOffsets[feedIndex]).dp)
+                    .offset(y = animationList[feedIndex].value.dp)
+                    .padding(horizontal = ((feedIndex - progress).coerceAtLeast(0f) * 16).dp),
+                feed = news[index],
+                cardColor = cardColors[index],
+                topPadding = topPaddings[feedIndex],
+                bottomPadding = bottomPaddings[feedIndex],
+                textStyle = textStyles[feedIndex],
+                showKeyword = keywordVisibilities[feedIndex],
+                visibleHeight = if (feedIndex < 3) 106 else null,
+                onHeightInflated = { height -> cardHeights[feedIndex] = height },
+                onClick = { onClick(feedIndex) },
             )
         }
 
         val lastIndex = news.size - 1
         val density = LocalDensity.current.density
 
-        // todo: 아래로 스와이프할 때 마지막 인덱스에 하나 추가
+        // 아래로 스와이프할 때 가장 뒤쪽 카드가 서서히 올라와요.
         if (progress > 0) {
             Card(
                 modifier = Modifier
@@ -567,7 +567,7 @@ private fun Cards(
             )
         }
 
-        // todo: 위로 스와이프할 때 첫 번째 인덱스에 하나 추가
+        // todo: 위로 스와이프할 때 가장 앞쪽 카드가 서서히 올라와요.
 //        if (progress < 0) {
 //            Card(
 //                modifier = Modifier

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -478,6 +478,7 @@ private fun Cards(
         }
 
         progress = scrollAccum / stepPx
+        println("${progress}, $scrollAccum, $stepPx")
     }
 
     LaunchedEffect(cardOffsets) {
@@ -518,7 +519,15 @@ private fun Cards(
 
             Card(
                 modifier = Modifier
-                    .graphicsLayer { translationY = scrollAccum }
+                    .graphicsLayer {
+                        if (progress < 0 && index == news.size - 1) {
+                            val dy = cardHeights[index].toFloat() * progress * density.density
+                            translationY = -dy
+                        } else {
+                            val dy = cardHeights[(index + 1).coerceAtMost(news.size - 1)].toFloat() * progress * density.density
+                            translationY = dy
+                        }
+                    }
                     .zIndex(5f - index)
                     .offset(y = (166 - cardOffsets[index]).dp)
                     .offset(y = animationList[index].value.dp)
@@ -534,6 +543,26 @@ private fun Cards(
                 onClick = { onClick(index) },
             )
         }
+
+//        if (progress < 0) {
+//            Card(
+//                modifier = Modifier
+//                    .graphicsLayer { translationY = scrollAccum }
+//                    .zIndex(5f - index)
+//                    .offset(y = (166 - cardOffsets[index]).dp)
+//                    .offset(y = animationList[index].value.dp)
+//                    .padding(horizontal = ((index - progress).coerceAtLeast(0f) * 16).dp),
+//                feed = news[feedIndex],
+//                cardColor = cardColors[feedIndex],
+//                topPadding = topPaddings[index],
+//                bottomPadding = bottomPaddings[index],
+//                textStyle = textStyles[index],
+//                showKeyword = keywordVisibilities[index],
+//                visibleHeight = if (index < 3) 106 else null,
+//                onHeightInflated = { height -> cardHeights[index] = height },
+//                onClick = { onClick(index) },
+//            )
+//        }
     }
 }
 

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -4,6 +4,9 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -40,6 +44,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -441,6 +446,32 @@ private fun Cards(
     val keywords = news.map { it.keyword }
     val cardColors = remember(news, colorType) { getCardColors(colorType, keywords) }
 
+    var start by remember { mutableIntStateOf(0) }
+    val mapFeedIndex = { index: Int -> (index + start) % news.size }
+
+    val density = LocalDensity.current
+    val stepDp = 106.dp
+    val stepPx = with(density) { stepDp.toPx() }
+
+    var scrollAccum by remember { mutableFloatStateOf(0f) }
+    val scrollState = rememberScrollableState { delta ->
+        scrollAccum += delta
+
+        delta
+    }
+
+    LaunchedEffect(scrollAccum) {
+        if (news.isEmpty()) return@LaunchedEffect
+
+        if (scrollAccum > stepPx) {
+            start = (start + 1) % news.size
+        }
+
+        if (scrollAccum < stepPx) {
+            start = (start - 1 + news.size) % news.size
+        }
+    }
+
     LaunchedEffect(cardOffsets) {
         if (news.isEmpty()) return@LaunchedEffect
 
@@ -468,13 +499,18 @@ private fun Cards(
     }
 
     Box(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .scrollable(orientation = Orientation.Vertical, state = scrollState),
         contentAlignment = Alignment.BottomCenter
     ) {
         // 항상 6
         repeat(news.size) { index ->
+            val feedIndex = mapFeedIndex(index)
+
             Card(
                 modifier = Modifier
+                    .graphicsLayer { translationY = scrollAccum }
                     .zIndex(5f - index)
                     .offset(y = (166 - cardOffsets[index]).dp)
                     .offset(y = animationList[index].value.dp)
@@ -516,7 +552,7 @@ private fun Card(
         modifier = modifier
             .bounceClick(onClick = onClick)
             .height(166.dp)
-            .clip(shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .clip(shape = RoundedCornerShape(24.dp))
             .background(color = cardColor)
     ) {
         val columnModifier = if (visibleHeight == null) {

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -567,24 +567,26 @@ private fun Cards(
             )
         }
 
-        // todo: 위로 스와이프할 때 가장 앞쪽 카드가 서서히 올라와요.
-//        if (progress < 0) {
-//            Card(
-//                modifier = Modifier
-//                    .graphicsLayer { translationY = progress * cardHeights[0] }
-//                    .zIndex(6f)
-//                    .offset(y = 0.dp),
-//                feed = news[lastIndex],
-//                cardColor = cardColors[lastIndex],
-//                topPadding = topPaddings[start],
-//                bottomPadding = bottomPaddings[start],
-//                textStyle = textStyles[start],
-//                showKeyword = keywordVisibilities[start],
-//                visibleHeight = null,
-//                onHeightInflated = { _ ->  },
-//                onClick = { onClick(start) },
-//            )
-//        }
+        // 위로 스와이프할 때 가장 앞쪽 카드가 서서히 올라와요.
+        // info: start - 1 은 마지막 index 이다.
+        if (news.isNotEmpty() && progress < 0) {
+            val risingIndex = (start - 1 + news.size) % news.size
+            Card(
+                modifier = Modifier
+                    .graphicsLayer { translationY = progress * cardHeights[0] * density }
+                    .zIndex(6f)
+                    .offset(y = 166.dp),
+                feed = news[risingIndex],
+                cardColor = cardColors[risingIndex],
+                topPadding = topPaddings[0],
+                bottomPadding = bottomPaddings[0],
+                textStyle = textStyles[0],
+                showKeyword = keywordVisibilities[0],
+                visibleHeight = 106,
+                onHeightInflated = { _ ->  },
+                onClick = { onClick(risingIndex) },
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -545,12 +545,13 @@ private fun Cards(
         }
 
         val lastIndex = news.size - 1
+        val density = LocalDensity.current.density
 
         // todo: 아래로 스와이프할 때 마지막 인덱스에 하나 추가
         if (progress > 0) {
             Card(
                 modifier = Modifier
-                    .graphicsLayer { translationY = -progress * cardHeights[lastIndex] }
+                    .graphicsLayer { translationY = -progress * cardHeights[lastIndex] * density }
                     .zIndex(-1f)
                     .offset(y = (166 - cardOffsets[(lastIndex - 1).coerceAtLeast(0)]).dp)
                     .padding(horizontal = ((lastIndex) * 16).dp),

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -453,6 +453,7 @@ private fun Cards(
     val stepPx = with(density) { stepDp.toPx() }
 
     var scrollAccum by remember { mutableFloatStateOf(0f) }
+    var progress by remember { mutableFloatStateOf(0f) }
     val scrollState = rememberScrollableState { delta ->
         scrollAccum += delta
 
@@ -471,6 +472,8 @@ private fun Cards(
             start = (start + 1) % news.size
             scrollAccum += stepPx
         }
+
+        progress = scrollAccum / stepPx
     }
 
     LaunchedEffect(cardOffsets) {
@@ -515,7 +518,7 @@ private fun Cards(
                     .zIndex(5f - index)
                     .offset(y = (166 - cardOffsets[index]).dp)
                     .offset(y = animationList[index].value.dp)
-                    .padding(horizontal = (index * 16).dp),
+                    .padding(horizontal = ((index - progress).coerceAtLeast(0f) * 16).dp),
                 feed = news[feedIndex],
                 cardColor = cardColors[feedIndex],
                 topPadding = topPaddings[index],

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -540,7 +540,7 @@ private fun Cards(
                 showKeyword = keywordVisibilities[feedIndex],
                 visibleHeight = if (feedIndex < 3) 106 else null,
                 onHeightInflated = { height -> cardHeights[feedIndex] = height },
-                onClick = { onClick(feedIndex) },
+                onClick = { onClick(index) },
             )
         }
 
@@ -557,10 +557,10 @@ private fun Cards(
                     .padding(horizontal = ((lastIndex) * 16).dp),
                 feed = news[start],
                 cardColor = cardColors[start],
-                topPadding = topPaddings[start],
-                bottomPadding = bottomPaddings[start],
-                textStyle = textStyles[start],
-                showKeyword = keywordVisibilities[start],
+                topPadding = topPaddings[lastIndex],
+                bottomPadding = bottomPaddings[lastIndex],
+                textStyle = textStyles[lastIndex],
+                showKeyword = keywordVisibilities[lastIndex],
                 visibleHeight = null,
                 onHeightInflated = { _ ->  },
                 onClick = { onClick(start) },

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -403,7 +403,6 @@ private fun Cards(
 ) {
     val topPaddings = listOf(20.dp, 20.dp, 20.dp, 20.dp, 16.dp, 16.dp)
     val bottomPaddings = listOf(16.dp, 16.dp, 16.dp, 16.dp, 12.dp, 12.dp)
-    val horizontalPaddings = listOf(0.dp, 16.dp, 32.dp, 48.dp, 64.dp, 80.dp)
     val keywordVisibilities = listOf(true, true, true, false, false, false)
     val textStyles = listOf(
         SoakTheme.typography.body18.copy(
@@ -464,11 +463,13 @@ private fun Cards(
         if (news.isEmpty()) return@LaunchedEffect
 
         if (scrollAccum > stepPx) {
-            start = (start + 1) % news.size
+            start = (start - 1 + news.size) % news.size
+            scrollAccum -= stepPx
         }
 
-        if (scrollAccum < stepPx) {
-            start = (start - 1 + news.size) % news.size
+        if (scrollAccum < -stepPx) {
+            start = (start + 1) % news.size
+            scrollAccum += stepPx
         }
     }
 
@@ -514,7 +515,7 @@ private fun Cards(
                     .zIndex(5f - index)
                     .offset(y = (166 - cardOffsets[index]).dp)
                     .offset(y = animationList[index].value.dp)
-                    .padding(horizontal = horizontalPaddings[index]),
+                    .padding(horizontal = (feedIndex * 16).dp),
                 feed = news[index],
                 cardColor = cardColors[index],
                 topPadding = topPaddings[index],

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -446,7 +446,7 @@ private fun Cards(
     val cardColors = remember(news, colorType) { getCardColors(colorType, keywords) }
 
     var start by remember { mutableIntStateOf(0) }
-    val mapFeedIndex = { index: Int -> (index + start) % news.size }
+    val mapFeedIndex = { index: Int -> (index - start + news.size) % news.size }
 
     val density = LocalDensity.current
     val stepDp = 106.dp
@@ -515,9 +515,9 @@ private fun Cards(
                     .zIndex(5f - index)
                     .offset(y = (166 - cardOffsets[index]).dp)
                     .offset(y = animationList[index].value.dp)
-                    .padding(horizontal = (feedIndex * 16).dp),
-                feed = news[index],
-                cardColor = cardColors[index],
+                    .padding(horizontal = (index * 16).dp),
+                feed = news[feedIndex],
+                cardColor = cardColors[feedIndex],
                 topPadding = topPaddings[index],
                 bottomPadding = bottomPaddings[index],
                 textStyle = textStyles[index],

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -544,23 +544,44 @@ private fun Cards(
             )
         }
 
+        val lastIndex = news.size - 1
+
+        // todo: 아래로 스와이프할 때 마지막 인덱스에 하나 추가
+        if (progress > 0) {
+            Card(
+                modifier = Modifier
+                    .graphicsLayer { translationY = -progress * cardHeights[lastIndex] }
+                    .zIndex(-1f)
+                    .offset(y = (166 - cardOffsets[(lastIndex - 1).coerceAtLeast(0)]).dp)
+                    .padding(horizontal = ((lastIndex) * 16).dp),
+                feed = news[start],
+                cardColor = cardColors[start],
+                topPadding = topPaddings[start],
+                bottomPadding = bottomPaddings[start],
+                textStyle = textStyles[start],
+                showKeyword = keywordVisibilities[start],
+                visibleHeight = null,
+                onHeightInflated = { _ ->  },
+                onClick = { onClick(start) },
+            )
+        }
+
+        // todo: 위로 스와이프할 때 첫 번째 인덱스에 하나 추가
 //        if (progress < 0) {
 //            Card(
 //                modifier = Modifier
-//                    .graphicsLayer { translationY = scrollAccum }
-//                    .zIndex(5f - index)
-//                    .offset(y = (166 - cardOffsets[index]).dp)
-//                    .offset(y = animationList[index].value.dp)
-//                    .padding(horizontal = ((index - progress).coerceAtLeast(0f) * 16).dp),
-//                feed = news[feedIndex],
-//                cardColor = cardColors[feedIndex],
-//                topPadding = topPaddings[index],
-//                bottomPadding = bottomPaddings[index],
-//                textStyle = textStyles[index],
-//                showKeyword = keywordVisibilities[index],
-//                visibleHeight = if (index < 3) 106 else null,
-//                onHeightInflated = { height -> cardHeights[index] = height },
-//                onClick = { onClick(index) },
+//                    .graphicsLayer { translationY = progress * cardHeights[0] }
+//                    .zIndex(6f)
+//                    .offset(y = 0.dp),
+//                feed = news[lastIndex],
+//                cardColor = cardColors[lastIndex],
+//                topPadding = topPaddings[start],
+//                bottomPadding = bottomPaddings[start],
+//                textStyle = textStyles[start],
+//                showKeyword = keywordVisibilities[start],
+//                visibleHeight = null,
+//                onHeightInflated = { _ ->  },
+//                onClick = { onClick(start) },
 //            )
 //        }
     }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/HomeScreen.kt
@@ -291,6 +291,8 @@ private fun HomeScreen(
                         },
                         colorType = colorType,
                         onCardsHeight = { height ->
+                            if (cardsHeight > 0.dp) return@Cards
+
                             cardsHeight = height.dp
                         },
                         modifier = Modifier.fillMaxWidth(0.5f)
@@ -321,6 +323,8 @@ private fun HomeScreen(
                         },
                         colorType = colorType,
                         onCardsHeight = { height ->
+                            if (cardsHeight > 0.dp) return@Cards
+
                             cardsHeight = height.dp
                         },
                     )


### PR DESCRIPTION
## Issue
- closed #92 

## Work Description
- 홈 화면의 카드 스크롤 애니메이션을 만들었어요.

## Screenshot
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/c96474d2-9091-46e5-84eb-edfdeaa9afb8



## To Reviewers
- 초기에 생각했던 부분까지만 구현했어요.
- 그러나 앞으로 해야할 일이 많아요. 앞으로 시간 날 때마다 최적화 해 나갈게요..
- 먼저 글자 크기를 1sp 단위가 아니라 0.x sp 단위로 스무스하게 변경해야 해요. 근데 이것도 테스트로 해봤는데 소수점 글자크기로 애니메이션 넣어도 그리 스무스하진 않더라구요.
- 스크롤 시 약간씩 툭 툭 튀는 현상이 발생해요.
- snap 기능을 넣어야 해요. 기본으로 제공되는 snapBehavior 인가 그거는 LazyColumn 전용으로 제공되는 것인데, 우리는 커스텀 스크롤이기 때문에 SnapLayoutInfoProvider를 직접 구현해야 해요.
- 성능을 벤치마킹 해 봐도 괜찮을 것 같아요.
