### PR TITLE
[FEAT] Explore 화면 최신순/오래된순 정렬 기능 추가 (#134)

### DIFF
--- a/data/src/main/java/com/fairyband/soak/data/datasource/NewsLetterDataSource.kt
+++ b/data/src/main/java/com/fairyband/soak/data/datasource/NewsLetterDataSource.kt
@@ -1,6 +1,7 @@
 package com.fairyband.soak.data.datasource
 
 import com.fairyband.soak.data.model.request.ContentProviderRequest
+import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.data.model.response.ExploreContentsResponse
 import com.fairyband.soak.data.model.response.LetterResponse
 import com.fairyband.soak.data.remote.service.NewsLetterService
@@ -18,9 +19,10 @@ class NewsLetterDataSource(
     }
 
     suspend fun getExploreContents(
-        nextOffset: Long
+        nextOffset: Long,
+        sort: Sort,
     ): ExploreContentsResponse {
-        return api.getExploreContents(lastSeenOffset = nextOffset, size = 20)
+        return api.getExploreContents(lastSeenOffset = nextOffset, size = 20, sort = sort.value)
     }
 
     suspend fun refreshContents(userId: Long) {

--- a/data/src/main/java/com/fairyband/soak/data/model/request/Sort.kt
+++ b/data/src/main/java/com/fairyband/soak/data/model/request/Sort.kt
@@ -1,0 +1,6 @@
+package com.fairyband.soak.data.model.request
+
+enum class Sort(val value: String) {
+    PUBLISHED("PUBLISHED"), // 최신순
+    REGISTERED("REGISTERED"),
+}

--- a/data/src/main/java/com/fairyband/soak/data/remote/service/NewsLetterService.kt
+++ b/data/src/main/java/com/fairyband/soak/data/remote/service/NewsLetterService.kt
@@ -22,6 +22,8 @@ interface NewsLetterService {
         lastSeenOffset: Long = 0,
         @Query("size")
         size: Int = 20,
+        @Query("sort")
+        sort: String = "PUBLISHED",
     ): ExploreContentsResponse
 
     @POST("api/newsletters/contents/{userId}/refresh")

--- a/data/src/main/java/com/fairyband/soak/data/repository/NewsRepository.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repository/NewsRepository.kt
@@ -1,9 +1,9 @@
 package com.fairyband.soak.data.repository
 
 import com.fairyband.soak.data.model.request.ContentProviderRequest
+import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.data.model.response.ExploreContentsResponse
 import com.fairyband.soak.data.model.response.LetterResponse
-import com.fairyband.soak.data.model.response.NewsResponse
 import kotlinx.coroutines.flow.Flow
 
 interface NewsRepository {
@@ -12,6 +12,6 @@ interface NewsRepository {
 
     suspend fun invalidateNews()
     fun refreshNews(): Flow<Unit>
-    suspend fun getExploreContents(): ExploreContentsResponse
+    suspend fun getExploreContents(sort: Sort?): ExploreContentsResponse
     suspend fun requestContentProvider(request: ContentProviderRequest)
 }

--- a/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
@@ -5,9 +5,9 @@ import com.fairyband.soak.data.datasource.AuthDataSource
 import com.fairyband.soak.data.datasource.NewsLetterDataSource
 import com.fairyband.soak.data.local.news.NewsDataStore
 import com.fairyband.soak.data.model.request.ContentProviderRequest
+import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.data.model.response.ExploreContentsResponse
 import com.fairyband.soak.data.model.response.LetterResponse
-import com.fairyband.soak.data.model.response.NewsResponse
 import com.fairyband.soak.data.repository.NewsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,6 +29,7 @@ class NewsRepositoryImpl(
 ) : NewsRepository {
     private val refreshFlow = MutableSharedFlow<Unit>()
     private var nextOffset = 0L
+    private var currentSort: Sort = Sort.PUBLISHED
 
     // 매일 자정에 뉴스를 새로고침해요.
     private val dayFlow = flow {
@@ -67,11 +68,13 @@ class NewsRepositoryImpl(
         emit(Unit)
     }
 
-    override suspend fun getExploreContents(): ExploreContentsResponse {
-        val response = newsLetterDataSource.getExploreContents(nextOffset)
-
+    override suspend fun getExploreContents(sort: Sort?): ExploreContentsResponse {
+        if (sort != null && sort != currentSort) {
+            nextOffset = 0L
+            currentSort = sort
+        }
+        val response = newsLetterDataSource.getExploreContents(nextOffset, currentSort)
         nextOffset = response.nextOffset
-
         return response
     }
 

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
@@ -37,14 +38,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.fairyband.soak.core.designsystem.systembar.DarkSystemBar
+import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.core.theme.LocalSoakColors
 import com.fairyband.soak.core.theme.SoakTheme
 import com.fairyband.soak.presentation.LocalNavController
@@ -89,10 +93,15 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
     }
     val feeds = state.feeds
     val totalCount = state.totalCount
+    val sortOrder = state.sort
 
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     val reportSuccessMessage = stringResource(R.string.explore_report_success)
+
+    LaunchedEffect(sortOrder) {
+        lazyState.scrollToItem(0)
+    }
 
     LaunchedEffect(lazyState) {
         snapshotFlow {
@@ -123,14 +132,43 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
         Column(
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
-            Text(
-                modifier = Modifier.padding(vertical = 8.dp),
-                text = stringResource(R.string.explore_count_of_articles, totalCount),
-                style = SoakTheme.typography.body14.copy(
-                    color = soakColors.textStrongInverse,
-                    fontWeight = FontWeight.Bold
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    text = stringResource(R.string.explore_count_of_articles, totalCount),
+                    style = SoakTheme.typography.body14.copy(
+                        color = soakColors.textStrongInverse,
+                        fontWeight = FontWeight.Bold
+                    )
                 )
-            )
+
+                Row(
+                    modifier = Modifier.clickable { viewModel.toggleOrder() },
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        ImageVector.vectorResource(R.drawable.ic_order),
+                        contentDescription = null,
+                        tint = Color.White,
+                    )
+                    Text(
+                        modifier = Modifier.padding(vertical = 8.dp),
+                        text = stringResource(
+                            if (sortOrder == Sort.PUBLISHED) R.string.explore_newest
+                            else R.string.explore_oldest
+                        ),
+                        style = SoakTheme.typography.body13.copy(
+                            color = soakColors.textStrongInverse,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    )
+                }
+            }
 
             LazyVerticalGrid(
                 state = lazyState,

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
@@ -186,7 +186,8 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
                             navController.navigate(
                                 MainDestination.ExploreDetail(
                                     feeds = feeds,
-                                    index = index
+                                    index = index,
+                                    totalCount = totalCount,
                                 )
                             )
                         },

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreState.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreState.kt
@@ -1,11 +1,13 @@
 package com.fairyband.soak.presentation.feature.explore
 
+import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.presentation.feature.home.bottomsheet.Preference
 import com.fairyband.soak.presentation.model.ExploreFeed
 
 data class ExploreState(
     val feeds: List<ExploreFeed> = emptyList(),
     val totalCount: Int = 0,
+    val sort: Sort = Sort.PUBLISHED,
     val name: String = "",
     val url: String = "",
     val selectedPreferences: List<Preference> = emptyList(),

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreViewModel.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreViewModel.kt
@@ -3,6 +3,7 @@ package com.fairyband.soak.presentation.feature.explore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fairyband.soak.data.model.request.ContentProviderRequest
+import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.data.repository.NewsRepository
 import com.fairyband.soak.presentation.feature.home.bottomsheet.Preference
 import com.fairyband.soak.presentation.model.toExploreFeed
@@ -71,7 +72,7 @@ class ExploreViewModel(
         if (loadingJob != null || !hasMore) return
 
         loadingJob = viewModelScope.launch {
-            val response = newsRepository.getExploreContents()
+            val response = newsRepository.getExploreContents(state.value.sort)
             val newFeeds = response.contents.map { it.toExploreFeed() }
             hasMore = response.hasMore
 
@@ -86,5 +87,14 @@ class ExploreViewModel(
         loadingJob?.invokeOnCompletion {
             loadingJob = null
         }
+    }
+
+    fun toggleOrder() {
+        val newSort = if (_state.value.sort == Sort.PUBLISHED) Sort.REGISTERED else Sort.PUBLISHED
+        loadingJob?.cancel()
+        loadingJob = null
+        hasMore = true
+        _state.update { it.copy(sort = newSort, feeds = emptyList(), totalCount = 0) }
+        loadFeeds()
     }
 }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/exploredetail/ExploreDetailScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/exploredetail/ExploreDetailScreen.kt
@@ -177,7 +177,7 @@ fun ExploreDetailScreen(
                 )
                 .width(300.dp)
                 .height(CARD_HEIGHT)
-                .padding(24.dp),
+                .padding(20.dp),
         ) {
             val titleColor = titleColors[index % 6]
             val feed = feeds[index]

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/exploredetail/ExploreDetailViewModel.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/exploredetail/ExploreDetailViewModel.kt
@@ -34,7 +34,7 @@ class ExploreDetailViewModel(
         if (loadingJob != null || !hasMore) return
 
         loadingJob = viewModelScope.launch {
-            val response = newsRepository.getExploreContents()
+            val response = newsRepository.getExploreContents(null)
             _totalCount.update { response.totalCount }
 
             val newFeeds = response.contents.map { it.toExploreFeed() }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/exploredetail/ExploreDetailViewModel.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/exploredetail/ExploreDetailViewModel.kt
@@ -18,7 +18,7 @@ class ExploreDetailViewModel(
     detail: MainDestination.ExploreDetail,
     private val newsRepository: NewsRepository,
 ) : ViewModel() {
-    private val _totalCount = MutableStateFlow(0)
+    private val _totalCount = MutableStateFlow(detail.totalCount)
     val totalCount = _totalCount.asStateFlow()
 
     private val _feeds: MutableStateFlow<List<ExploreFeed>> = MutableStateFlow(detail.feeds)

--- a/presentation/src/main/java/com/fairyband/soak/presentation/navigation/MainDestination.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/navigation/MainDestination.kt
@@ -44,5 +44,6 @@ sealed class MainDestination(val name: String) : NavKey {
     data class ExploreDetail(
         val index: Int,
         val feeds: List<ExploreFeed>,
+        val totalCount: Int,
     ) : MainDestination("explore_detail")
 }

--- a/presentation/src/main/res/drawable/ic_order.xml
+++ b/presentation/src/main/res/drawable/ic_order.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+  <group>
+    <clip-path
+        android:pathData="M14,14l-14,-0l-0,-14l14,-0z"/>
+    <path
+        android:pathData="M14,0l-14,0l-0,14l14,0z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/drawable/ic_order.xml
+++ b/presentation/src/main/res/drawable/ic_order.xml
@@ -3,11 +3,19 @@
     android:height="14dp"
     android:viewportWidth="14"
     android:viewportHeight="14">
-  <group>
-    <clip-path
-        android:pathData="M14,14l-14,-0l-0,-14l14,-0z"/>
-    <path
-        android:pathData="M14,0l-14,0l-0,14l14,0z"
-        android:fillColor="#ffffff"/>
-  </group>
+
+  <path
+      android:pathData="M4.5,11.1V3.2M1.9,5.4L4.5,2.8L7.1,5.4"
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="1.5"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round" />
+
+  <path
+      android:pathData="M9.5,2.9V10.8M6.9,8.6L9.5,11.2L12.1,8.6"
+      android:strokeColor="#FFFFFF"
+      android:strokeWidth="1.5"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round" />
+
 </vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
 
     <!--explore-->
     <string name="explore_count_of_articles">전체 (%d)</string>
+    <string name="explore_newest">최신순</string>
+    <string name="explore_oldest">오래된순</string>
     <string name="explore_report_fab">뉴스레터 제보</string>
     <string name="explore_report_bottomsheet_title">추가되었으면 하는\n뉴스레터나 블로그가 있나요?</string>
     <string name="explore_report_bottomsheet_subtitle">신규 뉴스레터를 제보해주세요</string>
@@ -176,7 +178,7 @@
         1. 사용자가 서비스를 이용하면서 발생하는 모든 개인 정보보호 관련 문의, 불만, 조언이나 기타 사항은 개인 정보 보호 책임자 및 담당 부서로 연락해 주시기 바랍니다. 쏙 사용자 목소리에 귀 기울이고 신속하고 충분한 답변을 드릴 수 있도록 최선을 다하겠습니다.\n\n
         제10조 (개인정보 보호 책임자)\n
         - 이름: 조성아\n
-        - 연락처: missionmateteam@gmail.com\n\n
+        - 연락처: newsletter.feeding@gmail.com\n\n
         제11조 (개인정보 처리방침의 변경)\n
         - 쏙 법령이나 서비스 변경에 따라 개인정보 처리방침을 수정할 수 있으며, 변경 사항은 서비스 화면에 공지합니다. 변경된 방침은 게시한 날로부터 7일 후 효력이 발생합니다.\n\n
         공고일자: 2025년 8월 23일\n


### PR DESCRIPTION
## Issue
- closed #134

## Work Description
Explore 화면에서 최신순 / 오래된순 정렬 기능을 추가했다. 데이터 레이어에 `Sort` enum 모델과 API 쿼리 파라미터를 추가하고, `NewsRepositoryImpl`에서 정렬 변경 시 `nextOffset`과 feeds를 리셋한다. ViewModel에는 `toggleOrder()`를 구현해 진행 중인 로드 job을 취소한 뒤 새 정렬 기준으로 첫 페이지부터 다시 로드하도록 처리했다.

UI에는 정렬 아이콘 버튼을 추가했으며, 정렬 변경 시 리스트가 상단으로 자동 스크롤된다. ExploreDetail 화면의 일부 수정 및 네비게이션 처리도 함께 포함된다.

## Screenshot
<!-- <img src="이미지 주소" width=270 /> -->

## To Reviewers
- `toggleOrder()` 호출 시 기존 `loadingJob` cancel → feeds 리셋 → 재로드 순서에서 경쟁 조건이 없는지 확인 필요
- `NewsRepositoryImpl`에서 정렬 변경 시 `nextOffset` 및 `hasMore` 플래그 리셋이 올바르게 처리되는지 검토
- `ExploreDetailScreen` 수정 및 `MainDestination` 변경으로 인한 네비게이션 사이드이펙트 확인
- 무한 스크롤 도중 정렬 전환하는 시나리오는 수동 검증 필요