### PR TITLE
Enhance/137 상태바 가시성 개선

### DIFF
--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/bottomsheet/ReportNewsletterBottomSheet.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/bottomsheet/ReportNewsletterBottomSheet.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.fairyband.soak.core.designsystem.bottomsheet.BaseBottomSheet
 import com.fairyband.soak.core.designsystem.button.BaseButton
+import com.fairyband.soak.core.designsystem.systembar.DarkSystemBar
 import com.fairyband.soak.core.theme.SoakTheme
 import com.fairyband.soak.presentation.R
 import com.fairyband.soak.presentation.analytics.SoakAnalytics
@@ -77,6 +78,8 @@ internal fun ReportNewsletterBottomSheet(
             shouldDismissOnBackPress = false
         )
     ) {
+        DarkSystemBar()
+
         val density = LocalDensity.current
         val isKeyboardVisible = WindowInsets.ime.getBottom(density) > 0
         val scope = rememberCoroutineScope()

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/setting/SettingScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/setting/SettingScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.fairyband.soak.core.designsystem.dialog.BaseDialog
+import com.fairyband.soak.core.designsystem.systembar.LightSystemBar
 import com.fairyband.soak.core.extension.noRippleClickable
 import com.fairyband.soak.core.extension.openAppNotificationSettings
 import com.fairyband.soak.core.theme.SoakTheme
@@ -59,6 +60,8 @@ internal fun SettingScreen(
     val navController = LocalNavController.current
     var bottomSheetVisibility by remember { mutableStateOf(false) }
     val context = LocalContext.current
+
+    LightSystemBar()
 
     if (bottomSheetVisibility) {
         HomeBottomSheet(

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/setting/personal/SettingPersonalScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/setting/personal/SettingPersonalScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.fairyband.soak.core.designsystem.systembar.LightSystemBar
 import com.fairyband.soak.core.extension.noRippleClickable
 import com.fairyband.soak.core.theme.SoakTheme
 import com.fairyband.soak.presentation.LocalNavController
@@ -25,6 +26,8 @@ import com.fairyband.soak.presentation.R
 @Composable
 internal fun SettingPersonalScreen() {
     val navController = LocalNavController.current
+
+    LightSystemBar()
 
     Column(
         modifier = Modifier.Companion

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/setting/service/SettingServiceScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/setting/service/SettingServiceScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.fairyband.soak.core.designsystem.systembar.LightSystemBar
 import com.fairyband.soak.core.extension.noRippleClickable
 import com.fairyband.soak.core.theme.SoakTheme
 import com.fairyband.soak.presentation.LocalNavController
@@ -25,6 +26,8 @@ import com.fairyband.soak.presentation.R
 @Composable
 internal fun SettingServiceScreen() {
     val navController = LocalNavController.current
+
+    LightSystemBar()
 
     Column(
         modifier = Modifier.Companion

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/webview/WebViewScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/webview/WebViewScreen.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import com.fairyband.soak.core.designsystem.systembar.LightSystemBar
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun WebViewScreen(url: String) {
+    LightSystemBar()
+
     AndroidView(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
## Issue
- closed #137 

## Work Description
- 탐색탭에서 웹뷰를 띄웠을 때 상태바 가시성 개선
- 설정 화면에서이 상태바 가시성 개선

## Screenshot

### before
<img src="https://github.com/user-attachments/assets/70723e67-d936-411b-aadd-988b0282ef10" width=270 />
<img src="https://github.com/user-attachments/assets/2df71031-c818-4159-8b6d-97d5b80affb1" width=270 />

### after
<img src="https://github.com/user-attachments/assets/a5bc5103-fc92-47b6-aabd-da67aff4dbae" width=270 />
<img src="https://github.com/user-attachments/assets/0737c39d-b862-4ee5-96d5-1472f5c09b5f" width=270 />

## To Reviewers
- dialog와 bottome sheet를 띄우는 곳에서는 자체 윈도우를 사용하기 때문에 해결이 좀 더 어려움. 나중에 해결 예정.
