### PR TITLE
[FEAT] 탐색 콘텐츠 정렬 API 수정

### DIFF
--- a/data/src/main/java/com/fairyband/soak/data/datasource/NewsLetterDataSource.kt
+++ b/data/src/main/java/com/fairyband/soak/data/datasource/NewsLetterDataSource.kt
@@ -1,7 +1,7 @@
 package com.fairyband.soak.data.datasource
 
 import com.fairyband.soak.data.model.request.ContentProviderRequest
-import com.fairyband.soak.data.model.request.Sort
+import com.fairyband.soak.data.model.request.Direction
 import com.fairyband.soak.data.model.response.ExploreContentsResponse
 import com.fairyband.soak.data.model.response.LetterResponse
 import com.fairyband.soak.data.remote.service.NewsLetterService
@@ -20,9 +20,14 @@ class NewsLetterDataSource(
 
     suspend fun getExploreContents(
         nextOffset: Long,
-        sort: Sort,
+        direction: Direction,
     ): ExploreContentsResponse {
-        return api.getExploreContents(lastSeenOffset = nextOffset, size = 20, sort = sort.value)
+        return api.getExploreContents(
+            lastSeenOffset = nextOffset,
+            size = 20,
+            sort = "PUBLISHED",
+            direction = direction.value,
+        )
     }
 
     suspend fun refreshContents(userId: Long) {

--- a/data/src/main/java/com/fairyband/soak/data/model/request/Direction.kt
+++ b/data/src/main/java/com/fairyband/soak/data/model/request/Direction.kt
@@ -1,0 +1,6 @@
+package com.fairyband.soak.data.model.request
+
+enum class Direction(val value: String) {
+    DESC("DESC"),
+    ASC("ASC"),
+}

--- a/data/src/main/java/com/fairyband/soak/data/model/request/Sort.kt
+++ b/data/src/main/java/com/fairyband/soak/data/model/request/Sort.kt
@@ -1,6 +1,0 @@
-package com.fairyband.soak.data.model.request
-
-enum class Sort(val value: String) {
-    PUBLISHED("PUBLISHED"), // 최신순
-    REGISTERED("REGISTERED"),
-}

--- a/data/src/main/java/com/fairyband/soak/data/remote/service/NewsLetterService.kt
+++ b/data/src/main/java/com/fairyband/soak/data/remote/service/NewsLetterService.kt
@@ -24,6 +24,8 @@ interface NewsLetterService {
         size: Int = 20,
         @Query("sort")
         sort: String = "PUBLISHED",
+        @Query("direction")
+        direction: String,
     ): ExploreContentsResponse
 
     @POST("api/newsletters/contents/{userId}/refresh")

--- a/data/src/main/java/com/fairyband/soak/data/repository/NewsRepository.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repository/NewsRepository.kt
@@ -1,7 +1,7 @@
 package com.fairyband.soak.data.repository
 
 import com.fairyband.soak.data.model.request.ContentProviderRequest
-import com.fairyband.soak.data.model.request.Sort
+import com.fairyband.soak.data.model.request.Direction
 import com.fairyband.soak.data.model.response.ExploreContentsResponse
 import com.fairyband.soak.data.model.response.LetterResponse
 import kotlinx.coroutines.flow.Flow
@@ -12,6 +12,6 @@ interface NewsRepository {
 
     suspend fun invalidateNews()
     fun refreshNews(): Flow<Unit>
-    suspend fun getExploreContents(sort: Sort?): ExploreContentsResponse
+    suspend fun getExploreContents(direction: Direction?): ExploreContentsResponse
     suspend fun requestContentProvider(request: ContentProviderRequest)
 }

--- a/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.fairyband.soak.data.datasource.AuthDataSource
 import com.fairyband.soak.data.datasource.NewsLetterDataSource
 import com.fairyband.soak.data.local.news.NewsDataStore
 import com.fairyband.soak.data.model.request.ContentProviderRequest
-import com.fairyband.soak.data.model.request.Sort
+import com.fairyband.soak.data.model.request.Direction
 import com.fairyband.soak.data.model.response.ExploreContentsResponse
 import com.fairyband.soak.data.model.response.LetterResponse
 import com.fairyband.soak.data.repository.NewsRepository
@@ -29,7 +29,7 @@ class NewsRepositoryImpl(
 ) : NewsRepository {
     private val refreshFlow = MutableSharedFlow<Unit>()
     private var nextOffset = 0L
-    private var currentSort: Sort = Sort.PUBLISHED
+    private var currentDirection: Direction = Direction.DESC
 
     // 매일 자정에 뉴스를 새로고침해요.
     private val dayFlow = flow {
@@ -68,12 +68,12 @@ class NewsRepositoryImpl(
         emit(Unit)
     }
 
-    override suspend fun getExploreContents(sort: Sort?): ExploreContentsResponse {
-        if (sort != null && sort != currentSort) {
+    override suspend fun getExploreContents(direction: Direction?): ExploreContentsResponse {
+        if (direction != null && direction != currentDirection) {
             nextOffset = 0L
-            currentSort = sort
+            currentDirection = direction
         }
-        val response = newsLetterDataSource.getExploreContents(nextOffset, currentSort)
+        val response = newsLetterDataSource.getExploreContents(nextOffset, currentDirection)
         nextOffset = response.nextOffset
         return response
     }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
@@ -48,9 +48,9 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.fairyband.soak.core.designsystem.systembar.DarkSystemBar
-import com.fairyband.soak.data.model.request.Sort
 import com.fairyband.soak.core.theme.LocalSoakColors
 import com.fairyband.soak.core.theme.SoakTheme
+import com.fairyband.soak.data.model.request.Direction
 import com.fairyband.soak.presentation.LocalNavController
 import com.fairyband.soak.presentation.LocalSnackbarController
 import com.fairyband.soak.presentation.R
@@ -93,13 +93,13 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
     }
     val feeds = state.feeds
     val totalCount = state.totalCount
-    val sortOrder = state.sort
+    val directionOrder = state.direction
 
     var showBottomSheet by rememberSaveable { mutableStateOf(false) }
 
     val reportSuccessMessage = stringResource(R.string.explore_report_success)
 
-    LaunchedEffect(sortOrder) {
+    LaunchedEffect(directionOrder) {
         lazyState.scrollToItem(0)
     }
 
@@ -159,7 +159,7 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
                     Text(
                         modifier = Modifier.padding(vertical = 8.dp),
                         text = stringResource(
-                            if (sortOrder == Sort.PUBLISHED) R.string.explore_newest
+                            if (directionOrder == Direction.DESC) R.string.explore_newest
                             else R.string.explore_oldest
                         ),
                         style = SoakTheme.typography.body13.copy(

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreState.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreState.kt
@@ -1,13 +1,13 @@
 package com.fairyband.soak.presentation.feature.explore
 
-import com.fairyband.soak.data.model.request.Sort
+import com.fairyband.soak.data.model.request.Direction
 import com.fairyband.soak.presentation.feature.home.bottomsheet.Preference
 import com.fairyband.soak.presentation.model.ExploreFeed
 
 data class ExploreState(
     val feeds: List<ExploreFeed> = emptyList(),
     val totalCount: Int = 0,
-    val sort: Sort = Sort.PUBLISHED,
+    val direction: Direction = Direction.DESC,
     val name: String = "",
     val url: String = "",
     val selectedPreferences: List<Preference> = emptyList(),

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreViewModel.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreViewModel.kt
@@ -3,7 +3,7 @@ package com.fairyband.soak.presentation.feature.explore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fairyband.soak.data.model.request.ContentProviderRequest
-import com.fairyband.soak.data.model.request.Sort
+import com.fairyband.soak.data.model.request.Direction
 import com.fairyband.soak.data.repository.NewsRepository
 import com.fairyband.soak.presentation.feature.home.bottomsheet.Preference
 import com.fairyband.soak.presentation.model.toExploreFeed
@@ -72,7 +72,7 @@ class ExploreViewModel(
         if (loadingJob != null || !hasMore) return
 
         loadingJob = viewModelScope.launch {
-            val response = newsRepository.getExploreContents(state.value.sort)
+            val response = newsRepository.getExploreContents(state.value.direction)
             val newFeeds = response.contents.map { it.toExploreFeed() }
             hasMore = response.hasMore
 
@@ -90,11 +90,11 @@ class ExploreViewModel(
     }
 
     fun toggleOrder() {
-        val newSort = if (_state.value.sort == Sort.PUBLISHED) Sort.REGISTERED else Sort.PUBLISHED
+        val newDirection = if (_state.value.direction == Direction.DESC) Direction.ASC else Direction.DESC
         loadingJob?.cancel()
         loadingJob = null
         hasMore = true
-        _state.update { it.copy(sort = newSort, feeds = emptyList(), totalCount = 0) }
+        _state.update { it.copy(direction = newDirection, feeds = emptyList(), totalCount = 0) }
         loadFeeds()
     }
 }


### PR DESCRIPTION
## Issue
- closed #141 

## Work Description
- published, registered가 둘 다 사용되던 것을 published로 고정하고, 정렬 기준은 asc, desc로 변경함
