### PR TITLE
[FEAT] 탐색탭 직군 필터 적용

### DIFF
--- a/data/src/main/java/com/fairyband/soak/data/datasource/NewsLetterDataSource.kt
+++ b/data/src/main/java/com/fairyband/soak/data/datasource/NewsLetterDataSource.kt
@@ -21,12 +21,14 @@ class NewsLetterDataSource(
     suspend fun getExploreContents(
         nextOffset: Long,
         direction: Direction,
+        categoryIds: List<String>?,
     ): ExploreContentsResponse {
         return api.getExploreContents(
             lastSeenOffset = nextOffset,
             size = 20,
             sort = "PUBLISHED",
             direction = direction.value,
+            categoryIds = categoryIds,
         )
     }
 

--- a/data/src/main/java/com/fairyband/soak/data/remote/service/NewsLetterService.kt
+++ b/data/src/main/java/com/fairyband/soak/data/remote/service/NewsLetterService.kt
@@ -26,6 +26,8 @@ interface NewsLetterService {
         sort: String = "PUBLISHED",
         @Query("direction")
         direction: String,
+        @Query("categoryIds")
+        categoryIds: List<String>? = null,
     ): ExploreContentsResponse
 
     @POST("api/newsletters/contents/{userId}/refresh")

--- a/data/src/main/java/com/fairyband/soak/data/repository/NewsRepository.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repository/NewsRepository.kt
@@ -12,6 +12,12 @@ interface NewsRepository {
 
     suspend fun invalidateNews()
     fun refreshNews(): Flow<Unit>
-    suspend fun getExploreContents(direction: Direction?): ExploreContentsResponse
+    /**
+     * @param categoryIds 직군 카테고리 ID 목록. 비어 있으면 전체 조회예요.
+     */
+    suspend fun getExploreContents(
+        direction: Direction?,
+        categoryIds: List<String> = emptyList(),
+    ): ExploreContentsResponse
     suspend fun requestContentProvider(request: ContentProviderRequest)
 }

--- a/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
+++ b/data/src/main/java/com/fairyband/soak/data/repositoryimpl/NewsRepositoryImpl.kt
@@ -30,6 +30,7 @@ class NewsRepositoryImpl(
     private val refreshFlow = MutableSharedFlow<Unit>()
     private var nextOffset = 0L
     private var currentDirection: Direction = Direction.DESC
+    private var currentCategoryIds: List<String> = emptyList()
 
     // 매일 자정에 뉴스를 새로고침해요.
     private val dayFlow = flow {
@@ -68,12 +69,24 @@ class NewsRepositoryImpl(
         emit(Unit)
     }
 
-    override suspend fun getExploreContents(direction: Direction?): ExploreContentsResponse {
+    override suspend fun getExploreContents(
+        direction: Direction?,
+        categoryIds: List<String>,
+    ): ExploreContentsResponse {
+        // keyset 커서는 정렬/필터 조합에 종속적이라, 조건이 바뀌면 처음부터 다시 조회해야 해요.
         if (direction != null && direction != currentDirection) {
             nextOffset = 0L
             currentDirection = direction
         }
-        val response = newsLetterDataSource.getExploreContents(nextOffset, currentDirection)
+        if (categoryIds != currentCategoryIds) {
+            nextOffset = 0L
+            currentCategoryIds = categoryIds
+        }
+        val response = newsLetterDataSource.getExploreContents(
+            nextOffset = nextOffset,
+            direction = currentDirection,
+            categoryIds = currentCategoryIds.ifEmpty { null },
+        )
         nextOffset = response.nextOffset
         return response
     }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreScreen.kt
@@ -1,6 +1,9 @@
 package com.fairyband.soak.presentation.feature.explore
 
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,9 +19,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -48,6 +53,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.fairyband.soak.core.designsystem.systembar.DarkSystemBar
+import com.fairyband.soak.core.extension.noRippleClickable
 import com.fairyband.soak.core.theme.LocalSoakColors
 import com.fairyband.soak.core.theme.SoakTheme
 import com.fairyband.soak.data.model.request.Direction
@@ -56,6 +62,7 @@ import com.fairyband.soak.presentation.LocalSnackbarController
 import com.fairyband.soak.presentation.R
 import com.fairyband.soak.presentation.analytics.SoakAnalytics
 import com.fairyband.soak.presentation.feature.explore.bottomsheet.ReportNewsletterBottomSheet
+import com.fairyband.soak.presentation.feature.home.bottomsheet.Preference
 import com.fairyband.soak.presentation.model.ExploreFeed
 import com.fairyband.soak.presentation.navigation.MainDestination
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -99,7 +106,7 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
 
     val reportSuccessMessage = stringResource(R.string.explore_report_success)
 
-    LaunchedEffect(directionOrder) {
+    LaunchedEffect(directionOrder, state.selectedJobFilters) {
         lazyState.scrollToItem(0)
     }
 
@@ -129,71 +136,81 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
     DarkSystemBar()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp)
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    modifier = Modifier.padding(vertical = 8.dp),
-                    text = stringResource(R.string.explore_count_of_articles, totalCount),
-                    style = SoakTheme.typography.body14.copy(
-                        color = soakColors.textStrongInverse,
-                        fontWeight = FontWeight.Bold
-                    )
-                )
+        Column {
+            JobFilterRow(
+                selectedJobFilters = state.selectedJobFilters,
+                isAllSelected = state.isAllJobFiltersSelected,
+                onAllClick = viewModel::selectAllJobFilters,
+                onJobClick = viewModel::toggleJobFilter,
+            )
 
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
                 Row(
-                    modifier = Modifier.clickable { viewModel.toggleOrder() },
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        ImageVector.vectorResource(R.drawable.ic_order),
-                        contentDescription = null,
-                        tint = Color.White,
-                    )
                     Text(
                         modifier = Modifier.padding(vertical = 8.dp),
-                        text = stringResource(
-                            if (directionOrder == Direction.DESC) R.string.explore_newest
-                            else R.string.explore_oldest
-                        ),
-                        style = SoakTheme.typography.body13.copy(
+                        text = stringResource(R.string.explore_count_of_articles, totalCount),
+                        style = SoakTheme.typography.body14.copy(
                             color = soakColors.textStrongInverse,
-                            fontWeight = FontWeight.SemiBold
+                            fontWeight = FontWeight.Bold
                         )
                     )
-                }
-            }
 
-            LazyVerticalGrid(
-                state = lazyState,
-                columns = GridCells.Fixed(2),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(
-                    top = 8.dp,
-                    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-                ),
-            ) {
-                items(count = feeds.size, key = { index -> feeds[index].id }) { index ->
-                    Card(
-                        modifier = Modifier.clickable {
-                            navController.navigate(
-                                MainDestination.ExploreDetail(
-                                    feeds = feeds,
-                                    index = index,
-                                    totalCount = totalCount,
-                                )
+                    Row(
+                        modifier = Modifier.clickable { viewModel.toggleOrder() },
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            ImageVector.vectorResource(R.drawable.ic_order),
+                            contentDescription = null,
+                            tint = Color.White,
+                        )
+                        Text(
+                            modifier = Modifier.padding(vertical = 8.dp),
+                            text = stringResource(
+                                if (directionOrder == Direction.DESC) R.string.explore_newest
+                                else R.string.explore_oldest
+                            ),
+                            style = SoakTheme.typography.body13.copy(
+                                color = soakColors.textStrongInverse,
+                                fontWeight = FontWeight.SemiBold
                             )
-                        },
-                        content = feeds[index],
-                        containerColor = cardColors[index % 6],
-                    )
+                        )
+                    }
+                }
+
+                LazyVerticalGrid(
+                    state = lazyState,
+                    columns = GridCells.Fixed(2),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(
+                        top = 8.dp,
+                        bottom = WindowInsets.navigationBars.asPaddingValues()
+                            .calculateBottomPadding()
+                    ),
+                ) {
+                    items(count = feeds.size, key = { index -> feeds[index].id }) { index ->
+                        Card(
+                            modifier = Modifier.clickable {
+                                navController.navigate(
+                                    MainDestination.ExploreDetail(
+                                        feeds = feeds,
+                                        index = index,
+                                        totalCount = totalCount,
+                                    )
+                                )
+                            },
+                            content = feeds[index],
+                            containerColor = cardColors[index % 6],
+                        )
+                    }
                 }
             }
         }
@@ -234,6 +251,80 @@ fun ExploreScreen(viewModel: ExploreViewModel = koinViewModel()) {
                 )
                 viewModel.reportNewsletter()
             },
+        )
+    }
+}
+
+@Composable
+private fun JobFilterRow(
+    selectedJobFilters: List<Preference>,
+    isAllSelected: Boolean,
+    onAllClick: () -> Unit,
+    onJobClick: (Preference) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        item {
+            JobFilterChip(
+                label = stringResource(R.string.explore_filter_all),
+                isSelected = isAllSelected,
+                onClick = onAllClick,
+            )
+        }
+        items(items = Preference.entries, key = { it.name }) { preference ->
+            JobFilterChip(
+                label = preference.label,
+                icon = preference.icon,
+                isSelected = preference in selectedJobFilters,
+                onClick = { onJobClick(preference) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun JobFilterChip(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    @DrawableRes icon: Int? = null,
+) {
+    Row(
+        modifier = modifier
+            .background(
+                color = if (isSelected) SoakTheme.colors.backgroundOnSurface else Color.Transparent,
+                shape = CircleShape,
+            )
+            .border(
+                width = if (isSelected) 1.dp else 0.5.dp,
+                color = if (isSelected) SoakTheme.colors.borderPrimary else SoakTheme.colors.borderActive,
+                shape = CircleShape,
+            )
+            .clip(CircleShape)
+            .noRippleClickable { onClick() }
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (icon != null) {
+            Image(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(icon),
+                contentDescription = null,
+            )
+        }
+        Text(
+            text = label,
+            style = SoakTheme.typography.caption12.copy(
+                color = if (isSelected) SoakTheme.colors.textPrimary else SoakTheme.colors.textStrongInverse,
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+            ),
         )
     }
 }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreState.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreState.kt
@@ -8,11 +8,18 @@ data class ExploreState(
     val feeds: List<ExploreFeed> = emptyList(),
     val totalCount: Int = 0,
     val direction: Direction = Direction.DESC,
+    val selectedJobFilters: List<Preference> = emptyList(),
     val name: String = "",
     val url: String = "",
     val selectedPreferences: List<Preference> = emptyList(),
     val language: String = "",
 ) {
+    /**
+     * 직군을 하나도 고르지 않았거나 모두 고른 상태는 '전체' 로 취급해요.
+     */
+    val isAllJobFiltersSelected: Boolean
+        get() = selectedJobFilters.isEmpty()
+
     val isSubmitEnabled: Boolean
         get() = name.isNotBlank() && url.isNotBlank() && selectedPreferences.isNotEmpty() && language.isNotBlank()
 }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreViewModel.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/explore/ExploreViewModel.kt
@@ -71,8 +71,11 @@ class ExploreViewModel(
     fun loadFeeds() {
         if (loadingJob != null || !hasMore) return
 
-        loadingJob = viewModelScope.launch {
-            val response = newsRepository.getExploreContents(state.value.direction)
+        val job = viewModelScope.launch {
+            val response = newsRepository.getExploreContents(
+                direction = state.value.direction,
+                categoryIds = state.value.selectedJobFilters.map { it.categoryId },
+            )
             val newFeeds = response.contents.map { it.toExploreFeed() }
             hasMore = response.hasMore
 
@@ -83,18 +86,53 @@ class ExploreViewModel(
                 )
             }
         }
+        loadingJob = job
 
-        loadingJob?.invokeOnCompletion {
-            loadingJob = null
+        // 취소된 이전 job 의 완료 콜백이 새 job 의 참조를 지우지 않도록 확인해요.
+        job.invokeOnCompletion {
+            if (loadingJob === job) loadingJob = null
         }
     }
 
     fun toggleOrder() {
         val newDirection = if (_state.value.direction == Direction.DESC) Direction.ASC else Direction.DESC
+        reloadWith { it.copy(direction = newDirection) }
+    }
+
+    /**
+     * 직군 필터를 토글해요.
+     *
+     * - 전체(선택 없음) 상태에서 하나를 고르면 해당 직군만 선택돼요.
+     * - 모든 직군이 선택되면 자동으로 전체 선택으로 바뀌어요.
+     */
+    fun toggleJobFilter(preference: Preference) {
+        val current = _state.value.selectedJobFilters
+        val updated = when {
+            current.isEmpty() -> listOf(preference)
+            preference in current -> current - preference
+            else -> Preference.entries.filter { it in current || it == preference }
+        }
+        val isAllSelected = updated.size == Preference.entries.size
+
+        reloadWith { it.copy(selectedJobFilters = if (isAllSelected) emptyList() else updated) }
+    }
+
+    /**
+     * '전체' 칩을 눌렀을 때 모든 직군 필터를 해제해요.
+     */
+    fun selectAllJobFilters() {
+        if (_state.value.selectedJobFilters.isEmpty()) return
+        reloadWith { it.copy(selectedJobFilters = emptyList()) }
+    }
+
+    /**
+     * 정렬/필터 조건이 바뀌면 keyset 커서가 무효해지므로 목록을 비우고 처음부터 다시 조회해요.
+     */
+    private fun reloadWith(update: (ExploreState) -> ExploreState) {
         loadingJob?.cancel()
         loadingJob = null
         hasMore = true
-        _state.update { it.copy(direction = newDirection, feeds = emptyList(), totalCount = 0) }
+        _state.update { update(it).copy(feeds = emptyList(), totalCount = 0) }
         loadFeeds()
     }
 }

--- a/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/bottomsheet/Preference.kt
+++ b/presentation/src/main/java/com/fairyband/soak/presentation/feature/home/bottomsheet/Preference.kt
@@ -6,31 +6,37 @@ enum class Preference(
     val label: String,
     val icon: Int,
     val stringValue: String,
+    val categoryId: String,
 ) {
     ANDROID(
         label = "AND",
         icon = R.drawable.ic_home_android,
-        stringValue = "ANDROID"
+        stringValue = "ANDROID",
+        categoryId = "4",
     ),
     IOS(
         label = "iOS",
         icon = R.drawable.ic_home_ios,
-        stringValue = "IOS"
+        stringValue = "IOS",
+        categoryId = "3",
     ),
     FRONTEND(
         label = "FE",
         icon = R.drawable.ic_home_frontend,
-        stringValue = "FRONTEND"
+        stringValue = "FRONTEND",
+        categoryId = "2",
     ),
     BACKEND(
         label = "BE",
         icon = R.drawable.ic_home_backend,
-        stringValue = "BACKEND"
+        stringValue = "BACKEND",
+        categoryId = "1",
     ),
     DEVOPS(
         label = "DEVOPS",
         icon = R.drawable.ic_home_devops,
-        stringValue = "DEVOPS"
+        stringValue = "DEVOPS",
+        categoryId = "5",
     );
 
     companion object {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
 
     <!--explore-->
     <string name="explore_count_of_articles">전체 (%d)</string>
+    <string name="explore_filter_all">전체</string>
     <string name="explore_newest">최신순</string>
     <string name="explore_oldest">오래된순</string>
     <string name="explore_report_fab">뉴스레터 제보</string>

--- a/presentation/src/test/java/com/fairyband/soak/presentation/feature/home/bottomsheet/PreferenceTest.kt
+++ b/presentation/src/test/java/com/fairyband/soak/presentation/feature/home/bottomsheet/PreferenceTest.kt
@@ -17,4 +17,16 @@ class PreferenceTest : StringSpec({
     "직군이 null 이면 null 을 반환한다" {
         Preference.from(null) shouldBe null
     }
+
+    "직군은 서버 카테고리 ID 로 매핑된다" {
+        Preference.BACKEND.categoryId shouldBe "1"
+        Preference.FRONTEND.categoryId shouldBe "2"
+        Preference.IOS.categoryId shouldBe "3"
+        Preference.ANDROID.categoryId shouldBe "4"
+        Preference.DEVOPS.categoryId shouldBe "5"
+    }
+
+    "카테고리 ID 는 직군마다 고유하다" {
+        Preference.entries.map { it.categoryId }.toSet().size shouldBe Preference.entries.size
+    }
 })


### PR DESCRIPTION
## Issue
- closed #152

## Work Description
탐색탭 상단에 직군 필터를 추가했습니다. 클라이언트에서 거르지 않고 `/api/newsletters/explore/contents` 의 `categoryIds` 파라미터로 서버에서 필터링합니다. 선택된 직군이 없는 상태를 '전체'로 취급해서, 전체일 때는 `categoryIds` 를 아예 보내지 않습니다. 전체 상태에서 특정 직군을 고르면 그 직군만 선택되고, 모든 직군을 고르면 자동으로 전체로 돌아옵니다.

서버의 `categoryIds` 는 숫자 ID(BE=1, FE=2, iOS=3, AND=4, DevOps=5)인데 앱의 `Preference.stringValue` 는 문자열(`BACKEND` 등)이라 그대로 쓸 수 없어, `Preference` 에 `categoryId` 를 추가하고 테스트로 고정했습니다. 또 keyset 커서(`nextOffset`)는 정렬/필터 조합에 종속적이라 필터가 바뀌면 0으로 리셋해 처음부터 다시 조회합니다. 리뷰 편의를 위해 데이터 레이어 → 매핑 → ViewModel → UI 순으로 커밋을 나눴고, 각 커밋은 순서대로 단독 빌드됩니다.

## Screenshot
<!-- <img src="이미지 주소" width=270 /> -->

## To Reviewers
- 아직 **실기기에서 렌더링을 확인하지 못했습니다.** 칩 UI는 눈으로 한 번 봐주시면 좋겠습니다.
- 디자인의 `fills-vibrant/tertiary`(#ededed) 토큰이 테마에 없어서, 탐색 화면이 이미 쓰는 `textStrongInverse`(white)로 대체했습니다. 팔레트에 추가하는 게 맞을지 봐주세요.
- `loadFeeds` 의 `invokeOnCompletion` 이 취소된 이전 job 의 콜백으로 새 job 참조를 지워 중복 로드가 날 수 있던 기존 레이스를 job 동일성 확인으로 함께 고쳤습니다(77c86ea). 원래 있던 문제지만 칩 연타로 재현되기 쉬워져 포함했습니다.
- 칩 행이 화면 끝까지 스크롤되도록 기존 좌우 16dp 패딩 밖으로 분리하며 `ExploreScreen` 구조를 한 겹 바꿨습니다. 정렬/개수 영역에 영향이 없는지 봐주세요.
- 필터 변경 시 GA 이벤트 로깅은 넣지 않았습니다. 필요하면 알려주세요.